### PR TITLE
Change zip file size to u64 to support larger zip files

### DIFF
--- a/src/put/zips.rs
+++ b/src/put/zips.rs
@@ -40,7 +40,7 @@ pub fn create(api_token: String, file_id: u32) -> Result<String, Box<dyn std::er
 pub struct CheckZipResponse {
     pub zip_status: String,
     pub url: String,
-    pub size: i32,
+    pub size: u64,
 }
 
 /// Checks the status of a given zip job


### PR DESCRIPTION
I was getting this error when trying to download a zip of 2.4gb

Creating ZIP...
thread 'main' panicked at 'checking zip status: reqwest::Error { kind: Decode, source: Error("invalid value: integer `2597727234`, expected i32", line: 1, column: 37) }', src/put/zips.rs:25:90
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

Changing the source as in this PR fixed that issue.